### PR TITLE
Keep the raw event after hoist, in case we want something

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -22,6 +22,7 @@ process_events <- function(events) {
       message_type = c("content", "msgtype"),
       body         = c("content", "body")
     ) |>
+    tibble::add_column(raw_event = events) |>
     dplyr::select(!event) |>
     dplyr::mutate(time = lubridate::as_datetime(time / 1000)) |>
     dplyr::arrange(time)


### PR DESCRIPTION
This puts the raw `list` object from the API in a new column. It's can be handy if you want to parse something unusual.