### PR TITLE
Try to improve table readability

### DIFF
--- a/inst/rmd/html_report.Rmd
+++ b/inst/rmd/html_report.Rmd
@@ -77,6 +77,7 @@ rooms$events |>
   dplyr::slice_head(n = 10) |>
   dplyr::mutate(body = stringr::str_replace_all(body, pattern = "\n", " ")) |>
   dplyr::rename(`random message` = body) |>
+  dplyr::mutate(`random message` = stringr::str_trunc(`random message`, 300)) |>
   knitr::kable(format = "html")
 ```
 

--- a/inst/rmd/style.css
+++ b/inst/rmd/style.css
@@ -1,8 +1,37 @@
 table {
-  margin: auto;
   border-top: 1px solid #666;
   border-bottom: 1px solid #666;
 }
 table thead th { border-bottom: 1px solid #ddd; }
-th, td { padding: 5px; }
 thead, tfoot, tr:nth-child(even) { background: #eee; }
+
+#top-ten-posters-by-message-count {
+  max-width: 100%;
+}
+
+table {
+  display: block;
+  overflow-x: auto;
+  width: fit-content;
+  max-width: 100%;
+  /*display: table;*/
+  table-layout: fixed;
+  /*width: 100%;*/
+  border-collapse: collapse;
+  margin-bottom: 14px;
+
+  th {
+    text-align: left !important;
+    padding: 0.5rem;
+    vertical-align: text-top;
+  }
+
+  td {
+    text-align: left !important;
+    padding: 0.5rem;
+    vertical-align: text-top;
+    code {
+      white-space: normal;
+    }
+  }
+}


### PR DESCRIPTION
I am not sure if this is better or worse tbh. The ellipsis via CSS dynamically only works for a single line which is also not great, hence done in R which equally is not great. 

Additionally, the scrollbar imho happens way too late in the table as well. But since it's a table cell, it's not possible to override it's cell height. 

There are ways to use grid + divs but this is not a div table and tbh accessiblity-wise that's not great. 

TLDR: Table CSS still sucks in 2023 but at least this doesn't massively overflow anymore and it scrolls on mobile.

![image](https://github.com/GregSutcliffe/ChatStat/assets/1374914/924c03aa-6ae3-4e10-81bb-fec24143798a)
