### PR TITLE
Replace httr with httr2 and upgrade matrix endpoint versions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,13 +22,13 @@ Description:
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.3.0
 Imports:
     curl,
     dplyr,
     ggplot2,
     glue,
-    httr,
+    httr2,
     igraph,
     lubridate,
     purrr,


### PR DESCRIPTION
This is mostly a modernizing thing. It shouldn't change the behavior at all.

It also changes the api to use the auth headers instead and adds ratelimits. These are tbh arbitrary but due to R speed limits are unlikely to be hit anyway I believe.